### PR TITLE
tests: Use slices instead of `vec!`

### DIFF
--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -286,12 +286,10 @@ mod re_tests {
 
     #[test]
     fn test_date() {
-        assert!(vec!["sunday", "saturday", "Monday"]
-            .into_iter()
-            .all(is_date));
-        assert!(vec!["sunday ", " saturday", " jan ", "sund"]
-            .into_iter()
-            .all(|v| !is_date(v)));
+        assert!(IntoIterator::into_iter(["sunday", "saturday", "Monday"]).all(is_date));
+        assert!(
+            IntoIterator::into_iter(["sunday ", " saturday", " jan ", "sund"]).all(|v| !is_date(v))
+        );
     }
 
     #[test]
@@ -301,14 +299,13 @@ mod re_tests {
 
     #[test]
     fn test_id() {
-        assert!(vec![
+        assert!(IntoIterator::into_iter([
             "aa:bb:cc:00:ff",
             "42.24.21.12",
             "abab-efef",
             "2022-02-03",
             "18:01:00.1"
-        ]
-        .into_iter()
+        ])
         .all(is_uid))
     }
 


### PR DESCRIPTION
Here we have constant data; there's no need to heap-allocate a
`Vec` to hold it.

Performance is obviously irrelevant for the tests here,
but it's useful to use slices where we can because it can happen
in more production code paths.

However, what you may have gotten tripped up on here is:
https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html

Basically in Rust 2018 and below, `["foo", "bar"].iter()` gives you `&&str`
by default.  So for now let's use the suggested workaround.

Or, you could bump to 2021 edition.