### PR TITLE
Update defaultApp attribute to support nix-2.8 

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,7 @@
         };
       in {
         defaultPackage = logreduce;
-        defaultApp = flake-utils.lib.mkApp { drv = logreduce; };
+        apps.default = flake-utils.lib.mkApp { drv = logreduce; };
         devShell = pkgs.mkShell {
           buildInputs = with pkgs; [ rustc cargo rustfmt openssl pkg-config ];
         };


### PR DESCRIPTION
Otherwise, the default app fails with:
  error: attribute 'defaultApp.x86_64-linux' should have type 'derivation'

See: https://github.com/numtide/flake-utils/issues/61